### PR TITLE
Feature: Add all available older `imap-backup` versions

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -153,6 +153,126 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+  build-9-3-0:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 9.3.0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.3.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.3.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.3.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
   build-9-2-0:
     runs-on: ubuntu-latest
     env:
@@ -273,8 +393,1568 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+  build-9-1-1:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 9.1.1
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.1.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.1.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.1.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-9-1-0:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 9.1.0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.1.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.1.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.1.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-9-0-2:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 9.0.2
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-9-0-0:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 9.0.0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/9.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-8-0-2:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 8.0.2
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-8-0-1:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 8.0.1
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-8-0-0:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 8.0.0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/8.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-7-0-2:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 7.0.2
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/7.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/7.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/7.0.2
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-6-3-0:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 6.3.0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.3.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.3.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.3.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-6-2-1:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 6.2.1
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.2.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.2.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.2.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-6-1-0:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 6.1.0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.1.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.1.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.1.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-6-0-1:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 6.0.1
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.0.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.0.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.0.1
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build-6-0-0:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT: 6.0.0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ env.VARIANT }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-${{ env.VARIANT }}-
+          ${{ runner.os }}-buildx-
+
+    # This step generates the docker tags
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v0.0.0'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get short commit hash E.g. 'abc0123'
+        SHA=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate docker image tags
+        # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
+        # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
+        REF_VARIANT="${REF}-${VARIANT}"
+        REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
+
+        # Pass variables to next step
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+        echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_ENV
+        echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_ENV
+
+    - name: Login to Docker Hub registry
+      # Run on master and tags
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (master)
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    - name: Build and push (release)
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: variants/6.0.0
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT }}
+          ${{ github.repository }}:${{ env.REF_VARIANT }}
+          ${{ github.repository }}:${{ env.REF_SHA_VARIANT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
   update-draft-release:
-    needs: [build-9-3-1, build-9-2-0]
+    needs: [build-9-3-1, build-9-3-0, build-9-2-0, build-9-1-1, build-9-1-0, build-9-0-2, build-9-0-0, build-8-0-2, build-8-0-1, build-8-0-0, build-7-0-2, build-6-3-0, build-6-2-1, build-6-1-0, build-6-0-1, build-6-0-0]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -287,7 +1967,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-9-3-1, build-9-2-0]
+    needs: [build-9-3-1, build-9-3-0, build-9-2-0, build-9-1-1, build-9-1-0, build-9-0-2, build-9-0-0, build-8-0-2, build-8-0-1, build-8-0-0, build-7-0-2, build-6-3-0, build-6-2-1, build-6-1-0, build-6-0-1, build-6-0-0]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -302,7 +1982,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-dockerhub-description:
-    needs: [build-9-3-1, build-9-2-0]
+    needs: [build-9-3-1, build-9-3-0, build-9-2-0, build-9-1-1, build-9-1-0, build-9-0-2, build-9-0-0, build-8-0-2, build-8-0-1, build-8-0-0, build-7-0-2, build-6-3-0, build-6-2-1, build-6-1-0, build-6-0-1, build-6-0-0]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,21 @@ imap-backup syncs IMAP as `.mbox` backup files, in contrast to [isync](https://g
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
 | `:9.3.1`, `:latest` | [View](variants/9.3.1) |
+| `:9.3.0` | [View](variants/9.3.0) |
 | `:9.2.0` | [View](variants/9.2.0) |
+| `:9.1.1` | [View](variants/9.1.1) |
+| `:9.1.0` | [View](variants/9.1.0) |
+| `:9.0.2` | [View](variants/9.0.2) |
+| `:9.0.0` | [View](variants/9.0.0) |
+| `:8.0.2` | [View](variants/8.0.2) |
+| `:8.0.1` | [View](variants/8.0.1) |
+| `:8.0.0` | [View](variants/8.0.0) |
+| `:7.0.2` | [View](variants/7.0.2) |
+| `:6.3.0` | [View](variants/6.3.0) |
+| `:6.2.1` | [View](variants/6.2.1) |
+| `:6.1.0` | [View](variants/6.1.0) |
+| `:6.0.1` | [View](variants/6.0.1) |
+| `:6.0.0` | [View](variants/6.0.0) |
 
 ## Usage
 

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -1,6 +1,20 @@
 $local:PACKAGE_VERSIONS = @(
     '9.3.1'
+    '9.3.0'
     '9.2.0'
+    '9.1.1'
+    '9.1.0'
+    '9.0.2'
+    '9.0.0'
+    '8.0.2'
+    '8.0.1'
+    '8.0.0'
+    '7.0.2'
+    '6.3.0'
+    '6.2.1'
+    '6.1.0'
+    '6.0.1'
+    '6.0.0'
 )
 # Docker image variants' definitions
 $local:VARIANTS_MATRIX = @(

--- a/variants/6.0.0/Dockerfile
+++ b/variants/6.0.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 6.0.0; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/6.0.0/docker-entrypoint.sh
+++ b/variants/6.0.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/6.0.1/Dockerfile
+++ b/variants/6.0.1/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 6.0.1; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/6.0.1/docker-entrypoint.sh
+++ b/variants/6.0.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/6.1.0/Dockerfile
+++ b/variants/6.1.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 6.1.0; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/6.1.0/docker-entrypoint.sh
+++ b/variants/6.1.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/6.2.1/Dockerfile
+++ b/variants/6.2.1/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 6.2.1; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/6.2.1/docker-entrypoint.sh
+++ b/variants/6.2.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/6.3.0/Dockerfile
+++ b/variants/6.3.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 6.3.0; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/6.3.0/docker-entrypoint.sh
+++ b/variants/6.3.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/7.0.2/Dockerfile
+++ b/variants/7.0.2/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 7.0.2; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/7.0.2/docker-entrypoint.sh
+++ b/variants/7.0.2/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/8.0.0/Dockerfile
+++ b/variants/8.0.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 8.0.0; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/8.0.0/docker-entrypoint.sh
+++ b/variants/8.0.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/8.0.1/Dockerfile
+++ b/variants/8.0.1/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 8.0.1; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/8.0.1/docker-entrypoint.sh
+++ b/variants/8.0.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/8.0.2/Dockerfile
+++ b/variants/8.0.2/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 8.0.2; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/8.0.2/docker-entrypoint.sh
+++ b/variants/8.0.2/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/9.0.0/Dockerfile
+++ b/variants/9.0.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 9.0.0; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/9.0.0/docker-entrypoint.sh
+++ b/variants/9.0.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/9.0.2/Dockerfile
+++ b/variants/9.0.2/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 9.0.2; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/9.0.2/docker-entrypoint.sh
+++ b/variants/9.0.2/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/9.1.0/Dockerfile
+++ b/variants/9.1.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 9.1.0; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/9.1.0/docker-entrypoint.sh
+++ b/variants/9.1.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/9.1.1/Dockerfile
+++ b/variants/9.1.1/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 9.1.1; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/9.1.1/docker-entrypoint.sh
+++ b/variants/9.1.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"

--- a/variants/9.3.0/Dockerfile
+++ b/variants/9.3.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2-alpine3.17
+
+RUN apk add --no-cache ca-certificates
+RUN set -eux; \
+    gem install imap-backup -v 9.3.0; \
+    imap-backup help > /dev/null
+
+WORKDIR /root
+VOLUME /root/.imap-backup
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/9.3.0/docker-entrypoint.sh
+++ b/variants/9.3.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    SUBCOMMANDS=$( imap-backup help | grep -E '^\s*imap-backup' | awk '{print $2}' | sort -n | uniq )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        exec imap-backup "$@"
+    fi
+else
+    exec imap-backup "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Previously, only the latest two stable versions of `imap-backup` were available.  Although later versions would have fixed many older bugs, certain users might want to use older stable versions for various reasons.

All older available versions between `6.x.x` and `9.x.x` of `imap-backup` images' are now built.

See [here](https://github.com/joeyates/imap-backup/releases) for `imap-backup` changelog.

Addresses #16
