### PR TITLE
Hotfix: Exclude `10.0.0` variants since it is a bad release

### DIFF
--- a/Update-Versions.ps1
+++ b/Update-Versions.ps1
@@ -47,7 +47,10 @@ try {
     # Get my versions from generate/definitions/versions.json
     $versions = Get-Content $PSScriptRoot/generate/definitions/versions.json -Encoding utf8 | ConvertFrom-Json
     # Get new versions
-    $versionsNew = (Invoke-WebRequest https://rubygems.org/api/v1/versions/imap-backup.json).Content | ConvertFrom-Json | % { $_.number } | ? { $_ -match '^\d+\.\d+\.\d+$' }
+    $versionsNewExcluded = @(
+        '10.0.0'    # Bad release. imap-backup 10.0.0 throws exception when being run. See: https://github.com/joeyates/imap-backup/releases/tag/v10.0.1
+    )
+    $versionsNew = (Invoke-WebRequest https://rubygems.org/api/v1/versions/imap-backup.json).Content | ConvertFrom-Json | % { $_.number } | ? { $_ -match '^\d+\.\d+\.\d+$' } | ? { $_ -notin $versionsNewExcluded }
     # Get changed versions
     $changeScope = 'patch'
     $versionsChanged = Get-VersionsChanged -Versions $versions -VersionsNew $versionsNew -ChangeScope $changeScope -AsObject -Descending


### PR DESCRIPTION
Closes #34
